### PR TITLE
Remove array comprehension and add support for saving to Pocket

### DIFF
--- a/abouttabs.html
+++ b/abouttabs.html
@@ -71,6 +71,7 @@
         <a href="#" template-if="${length}" event-click="toggle(this.parentNode.parentNode.parentNode)">(${length}_tab)</a>
         <a href="#" event-click="${dedup}" template-if="${dedup}">[Dedup]</a>
         <a href="#" event-click="${switchTo}" template-if="${!length}">[Switch to]</a>
+        <a href="#" event-click="${saveAndClose}">[Save to Pocket and Close]</a>
         <a href="#" event-click="${close}">[Close]</a>
       </div>
     </div>

--- a/install.rdf
+++ b/install.rdf
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?><RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
   <Description about="urn:mozilla:install-manifest">
     <em:id>tabstats@glandium.org</em:id>
-    <em:version>0.1.1</em:version>
+    <em:version>0.1.2</em:version>
     <em:type>2</em:type>
     <em:bootstrap>true</em:bootstrap>
 
-    <!-- Target Application this extension can install into, 
-         with minimum and maximum supported versions. For a list 
+    <!-- Target Application this extension can install into,
+         with minimum and maximum supported versions. For a list
          of valid values, see:
 
          https://addons.mozilla.org/en-US/firefox/pages/appversions
-     --> 
+     -->
 
     <!-- Firefox -->
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>31.0</em:minVersion>
-        <em:maxVersion>41.0a1</em:maxVersion>
+        <em:maxVersion>46.0a1</em:maxVersion>
       </Description>
     </em:targetApplication>
 
@@ -26,10 +26,11 @@
     <em:description>Provide some data about open tabs.</em:description>
     <em:creator>Mike Hommey &lt;mh@glandium.org&gt;</em:creator>
     <em:contributor>Steve Fink %lt;sphink@gmail.com&gt;</em:contributor>
+    <em:contributor>Till Schneidereit %lt;till@tillschneidereit.net&gt;</em:contributor>
 
     <em:iconURL/>
-    
+
     <em:optionsURL/>
-    
+
   </Description>
 </RDF>


### PR DESCRIPTION
Without the first of these patches, the addon stops working in current Nightly.

The second patch adds rudimentary support for Pocket. Storing my hundreds of news articles I probably won't ever read to Pocket instead of keeping them in my session wasn't really feasible without this.
