### PR TITLE
Allow clicking on the li arrow

### DIFF
--- a/abouttabs.html
+++ b/abouttabs.html
@@ -34,27 +34,27 @@
 </template>
 
 <template id="main_group">
-  <li template-if="${numDupes}" class="group">
-    <span event-click="${toggleParent}">${length}_unique_${what}</span>
+  <li event-click="${toggleSelf}" template-if="${numDupes}" class="group">
+    <span>${length}_unique_${what}</span>
     <ul template="main_group_with_dupes"></ul>
   </li>
-  <li template-if="${!numDupes}" class="group closed">
-    <span event-click="${toggleParent}">${numUnique}_unique_${what}</span>
+  <li event-click="${toggleSelf}" template-if="${!numDupes}" class="group closed">
+    <span>${numUnique}_unique_${what}</span>
     <ul class="${what}" template-delay="item" template-data="${unique.byLastAccessed}"></ul>
   </li>
 </template>
 
 <template id="main_group_with_dupes">
-  <li class="group">
-    <span event-click="${toggleParent}">${numDupes}_${what} in more than 1 tab</span>
+  <li event-click="${toggleSelf}" class="group">
+    <span>${numDupes}_${what} in more than 1 tab</span>
     <span class="actions">
       <a href="#" event-click="${dupes.dedup}" template-if="${dupes.dedup}">[Dedup]</a>
       <a href="#" event-click="${dupes.close}">[Close]</a>
     </span>
     <ul class="${what}" template="item" template-data="${dupes.byLength}"></ul>
   </li>
-  <li class="group closed">
-    <span event-click="${toggleParent}">${numUnique}_other_${what}</span>
+  <li event-click="${toggleSelf}" class="group closed">
+    <span>${numUnique}_other_${what}</span>
     <ul class="${what}" template-delay="item" template-data="${unique.byLastAccessed}"></ul>
   </li>
 </template>

--- a/abouttabs.html
+++ b/abouttabs.html
@@ -36,18 +36,18 @@
 <template id="main_group">
   <li event-click="${toggleSelf}" template-if="${numDupes}" class="group">
     <span>${length}_unique_${what}</span>
-    <ul template="main_group_with_dupes"></ul>
+    <ul event-click="${squashEvent}" template="main_group_with_dupes"></ul>
   </li>
   <li event-click="${toggleSelf}" template-if="${!numDupes}" class="group closed">
     <span>${numUnique}_unique_${what}</span>
-    <ul class="${what}" template-delay="item" template-data="${unique.byLastAccessed}"></ul>
+    <ul event-click="${squashEvent}" class="${what}" template-delay="item" template-data="${unique.byLastAccessed}"></ul>
   </li>
 </template>
 
 <template id="main_group_with_dupes">
   <li event-click="${toggleSelf}" class="group">
     <span>${numDupes}_${what} in more than 1 tab</span>
-    <span class="actions">
+    <span event-click="${squashEvent}" class="actions">
       <a href="#" event-click="${dupes.dedup}" template-if="${dupes.dedup}">[Dedup]</a>
       <a href="#" event-click="${dupes.close}">[Close]</a>
     </span>
@@ -55,12 +55,12 @@
   </li>
   <li event-click="${toggleSelf}" class="group closed">
     <span>${numUnique}_other_${what}</span>
-    <ul class="${what}" template-delay="item" template-data="${unique.byLastAccessed}"></ul>
+    <ul event-click="${squashEvent}" class="${what}" template-delay="item" template-data="${unique.byLastAccessed}"></ul>
   </li>
 </template>
 
 <template id="item">
-  <li class="closed">
+  <li event-click="${squashEvent}" class="closed">
     <div>
 <!--
       <xul:image validate="never" template-if="${favicon}" src="${favicon}"></xul:image>
@@ -88,7 +88,7 @@
 </template>
 
 <template id="select_dedup">
-  <li>
+  <li event-click="${squashEvent}">
     <span template="last_accessed"></span>
     <span class="actions">
       <a href="#" event-click="${switchTo}">[Switch to]</a>

--- a/abouttabs.js
+++ b/abouttabs.js
@@ -262,8 +262,9 @@ function refreshTabs(windows) {
   templates.main.instantiate(body, data);
 }
 
-function toggleParent(ev) {
-  toggle(ev.currentTarget.parentNode);
+function toggleSelf(ev) {
+  ev.stopPropagation();
+  toggle(ev.currentTarget);
 }
 
 function toggleParentParentParent(ev) {

--- a/abouttabs.js
+++ b/abouttabs.js
@@ -262,6 +262,10 @@ function refreshTabs(windows) {
   templates.main.instantiate(body, data);
 }
 
+function squashEvent(ev) {
+  ev.stopPropagation();
+}
+
 function toggleSelf(ev) {
   ev.stopPropagation();
   toggle(ev.currentTarget);


### PR DESCRIPTION
Moving the click handler to the 'li' itself lets us click the arrow as
well, not just the span.

We also have to stop the event propagating the parent ul, which is
presumably why the span was picked in the first place.